### PR TITLE
Fix bug with tags that have a count.

### DIFF
--- a/conda_rpms/build_rpm_structure.py
+++ b/conda_rpms/build_rpm_structure.py
@@ -170,7 +170,7 @@ def create_rpmbuild_content(repo, target, config):
                 fname = '{}-env-{}-label-{}.spec'.format(rpm_prefix, branch.name, label)
                 with open(os.path.join(target, 'SPECS', fname), 'w') as fh:
                     fh.write(generate.render_env(branch.name, label,
-                                                 repo, config, tag, commit_num))
+                                                 config, tag, commit_num))
 
 
 def create_rpm_installer(target, config, python_spec='python'):

--- a/conda_rpms/generate.py
+++ b/conda_rpms/generate.py
@@ -58,6 +58,9 @@ def render_env(branch_name, label, config, tag, commit_num):
                 'label' : label,
                 'summary': 'A {} environment.'.format(rpm_prefix),
                 'version': commit_num,}
+    # When multiple tags are produced in a day, they have an associated count
+    # addded to the end e.g. env-default-2016_12_05-2, which needs to be parsed
+    # correctly.
     tag_name, = tag.split('-', 2)[2:]
     return env_spec_tmpl.render(install_prefix=install_prefix,
                                 rpm_prefix=rpm_prefix, env=env_info,

--- a/conda_rpms/generate.py
+++ b/conda_rpms/generate.py
@@ -66,13 +66,12 @@ def render_env(branch_name, label, config, tag, commit_num):
     # addded to the end e.g. env-default-2016_12_05-2, which needs to be parsed
     # correctly.
     match = tag_pattern.match(tag)
-    try:
-        tag_name = match.group(1)
-    except AttributeError:
+    if match is None:
         msg = "Cannot create an environment for the tag {}. The name of the " \
               "tag must follow the format " \
               "'env-<environment name>-YYYY-MM-DD(-<count> (optional))'"
         raise ValueError(msg.format(tag))
+    tag_name = match.group(1)
     return env_spec_tmpl.render(install_prefix=install_prefix,
                                 rpm_prefix=rpm_prefix, env=env_info,
                                 labelled_tag=tag_name)

--- a/conda_rpms/generate.py
+++ b/conda_rpms/generate.py
@@ -17,6 +17,9 @@ import re
 import tarfile
 import yaml
 
+TAG_PATTERN = '^env-\w+-(\d{4}_\d{2}_\d{2}(-\d+)?)$'
+tag_pattern = re.compile(TAG_PATTERN)
+
 
 def render_dist_spec(dist, config):
     with tarfile.open(dist, 'r:bz2') as tar:
@@ -62,12 +65,13 @@ def render_env(branch_name, label, config, tag, commit_num):
     # When multiple tags are produced in a day, they have an associated count
     # addded to the end e.g. env-default-2016_12_05-2, which needs to be parsed
     # correctly.
-    tag_pattern = re.compile('env\-[a-zA-Z]+\-([0-9\_\-]+)')
+    match = tag_pattern.match(tag)
     try:
-        tag_name, = tag_pattern.match(tag).groups()
+        tag_name = match.group(1)
     except AttributeError:
         msg = "Cannot create an environment for the tag {}. The name of the " \
-              "tag must follow the format 'env-<environment name>-<env tag>"
+              "tag must follow the format " \
+              "'env-<environment name>-YYYY-MM-DD(-<count> (optional))'"
         raise ValueError(msg.format(tag))
     return env_spec_tmpl.render(install_prefix=install_prefix,
                                 rpm_prefix=rpm_prefix, env=env_info,

--- a/conda_rpms/generate.py
+++ b/conda_rpms/generate.py
@@ -49,17 +49,19 @@ def render_dist_spec(dist, config):
                                 rpm_prefix=rpm_prefix,
                                 install_prefix=install_prefix)
 
-def render_env(branch_name, label, repo, config, tag, commit_num):
-    env_info = {'url': 'http://link/to/gh',
-                'name': branch_name,
-		'label' : label,
-                'summary': 'A SciTools environment.',
-                'version': commit_num,}
+
+def render_env(branch_name, label, config, tag, commit_num):
     install_prefix = config['install']['prefix']
     rpm_prefix = config['rpm']['prefix']
+    env_info = {'url': 'http://link/to/gh',
+                'name': branch_name,
+                'label' : label,
+                'summary': 'A {} environment.'.format(rpm_prefix),
+                'version': commit_num,}
+    tag_name, = tag.split('-', 2)[2:]
     return env_spec_tmpl.render(install_prefix=install_prefix,
                                 rpm_prefix=rpm_prefix, env=env_info,
-                                labelled_tag=tag.split('-')[-1])
+                                labelled_tag=tag_name)
 
 
 def render_taggedenv(env_name, tag, pkgs, config, env_spec):

--- a/conda_rpms/tests/unit/generate/test_render_env.py
+++ b/conda_rpms/tests/unit/generate/test_render_env.py
@@ -1,0 +1,27 @@
+import unittest
+
+from conda_rpms.generate import render_env
+
+
+class Test_tag(unittest.TestCase):
+    def check(self, tag, expected):
+        config = {'install': {'prefix': '/data/local'},
+                  'rpm': {'prefix': 'Tools'}
+                  }
+        r = render_env(branch_name='default', label='next', config=config,
+                       tag=tag, commit_num=30)
+        result_requires = [
+            line for line in r.split('\n') if line.startswith('Requires: ')]
+        self.assertEqual(result_requires, expected)
+
+    def test_tag(self):
+        self.check(tag='env-default-2016_12_15',
+                   expected=['Requires: Tools-env-default-tag-2016_12_15'])
+
+    def test_tag_with_count(self):
+        self.check(tag='env-default-2016_12_15-2',
+                   expected=['Requires: Tools-env-default-tag-2016_12_15-2'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_rpms/tests/unit/generate/test_render_env.py
+++ b/conda_rpms/tests/unit/generate/test_render_env.py
@@ -22,6 +22,10 @@ class Test_tag(unittest.TestCase):
         self.check(tag='env-default-2016_12_15-2',
                    expected=['Requires: Tools-env-default-tag-2016_12_15-2'])
 
+    def test_bad_tag(self):
+        msg = "Cannot create an environment for the tag"
+        with self.assertRaisesRegexp(ValueError, msg):
+            self.check(tag='env-defa-ult-2016_12_15-2', expected=None)
 
 if __name__ == '__main__':
     unittest.main()

--- a/conda_rpms/tests/unit/generate/test_render_env.py
+++ b/conda_rpms/tests/unit/generate/test_render_env.py
@@ -4,11 +4,11 @@ from conda_rpms.generate import render_env
 
 
 class Test_tag(unittest.TestCase):
-    def check(self, tag, expected):
+    def check(self, tag, branch_name='default', expected=None):
         config = {'install': {'prefix': '/data/local'},
                   'rpm': {'prefix': 'Tools'}
                   }
-        r = render_env(branch_name='default', label='next', config=config,
+        r = render_env(branch_name=branch_name, label='next', config=config,
                        tag=tag, commit_num=30)
         result_requires = [
             line for line in r.split('\n') if line.startswith('Requires: ')]
@@ -22,10 +22,16 @@ class Test_tag(unittest.TestCase):
         self.check(tag='env-default-2016_12_15-2',
                    expected=['Requires: Tools-env-default-tag-2016_12_15-2'])
 
+    def test_alphanumeric_branch_name(self):
+        branch = 'default12'
+        self.check(tag='env-{}-2016_12_15-2'.format(branch),
+                   branch_name=branch,
+                   expected=['Requires: Tools-env-default12-tag-2016_12_15-2'])
+
     def test_bad_tag(self):
         msg = "Cannot create an environment for the tag"
         with self.assertRaisesRegexp(ValueError, msg):
-            self.check(tag='env-defa-ult-2016_12_15-2', expected=None)
+            self.check(tag='env-defa-ult-2016_12_15-2')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We tried to create a 'labelled environment RPM' using a label that pointed
`next` > `2016_12_15-2`
Unfortunately it was parsed in correctly, and tried to do:
`next` > `2`
so we got:
`Requires: SciTools-env-default-tag-2`
rather than
`Requires: SciTools-env-default-tag-2016_12_15-2`
in the RPM SPEC.

This PR should fix that.

The only problem now is if someone uses conda-gitenv to autotag a environment repo with a branch that has a `-` in it (see conda-gitenv). Perhaps this could be fixed in conda-gitenv by erroring if the branch name has a `-`?

This replaces the incorrect PR to pelson/conda-rpms (https://github.com/pelson/conda-rpms/pull/42)