### PR TITLE
Add modules

### DIFF
--- a/conda_rpms/generate.py
+++ b/conda_rpms/generate.py
@@ -6,9 +6,10 @@ template_dir = os.path.join(os.path.dirname(__file__), 'templates')
 loader = jinja2.FileSystemLoader(template_dir)
 
 env = jinja2.Environment(loader=loader)
+env_trim_blocks = jinja2.Environment(loader=loader, trim_blocks=True)
 
 pkg_spec_tmpl = env.get_template('pkg.spec.template')
-env_spec_tmpl = env.get_template('env.spec.template')
+env_spec_tmpl = env_trim_blocks.get_template('env.spec.template')
 taggedenv_spec_tmpl = env.get_template('taggedenv.spec.template')
 installer_spec_tmpl = env.get_template('installer.spec.template')
 
@@ -56,6 +57,7 @@ def render_dist_spec(dist, config):
 
 def render_env(branch_name, label, config, tag, commit_num):
     install_prefix = config['install']['prefix']
+    module_prefix = config['module']['prefix']
     rpm_prefix = config['rpm']['prefix']
     env_info = {'url': 'http://link/to/gh',
                 'name': branch_name,
@@ -74,6 +76,7 @@ def render_env(branch_name, label, config, tag, commit_num):
     tag_name = match.group(1)
     return env_spec_tmpl.render(install_prefix=install_prefix,
                                 rpm_prefix=rpm_prefix, env=env_info,
+                                module_prefix=module_prefix,
                                 labelled_tag=tag_name)
 
 

--- a/conda_rpms/templates/env.spec.template
+++ b/conda_rpms/templates/env.spec.template
@@ -4,9 +4,9 @@ Release:        0
 Summary:        {{ env.summary }}
 
 License:        BSD 3
-{% if env.url -%}
+{% if env.url %}
 URL:            {{ env.url }}
-{%- endif %}
+{% endif %}
 BuildRoot:      %{_tmppath}/env-{{ env.name }}-label-{{ env.label }}-{{ env.version }}
 
 Requires: {{ rpm_prefix }}-env-{{ env.name }}-tag-{{ labelled_tag }}
@@ -24,6 +24,55 @@ rm -rf $RPM_BUILD_ROOT/
 %install
 mkdir -p $RPM_BUILD_ROOT{{ install_prefix }}/environments/{{ env.name }}
 ln -s {{ install_prefix }}/environments/{{ env.name }}/{{ labelled_tag }} $RPM_BUILD_ROOT{{ install_prefix }}/environments/{{ env.name }}/{{ env.label }}
+mkdir -p $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}
+cat <<'EOF1' > $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}/{{ env.name }}-{{ env.label }}
+#%Module1.0
+#
+# scitools - scientific software stack
+#
+
+set ENV_LABEL "{{ env.name }}/{{ env.label }}"
+set BASE_DIR "/opt/scitools/environments/$ENV_LABEL"
+set HELP "Scientific software stack for the '$ENV_LABEL' environment."
+
+
+proc ModulesHelp { } {
+    global BASE_DIR
+    global HELP
+
+    puts stderr $HELP
+    puts stderr ""
+    puts stderr "Environment base directory is $BASE_DIR"
+}
+
+
+module-whatis $HELP
+conflict scitools
+prepend-path PATH $BASE_DIR/bin
+
+if { [ module-info mode load ] } {
+    puts stderr "[ module-info name ] loaded."
+}
+
+if { [ string equal [ module-info mode ] "switch2" ] } {
+    puts stderr "[ module-info name ] switched in."
+}
+
+if { [ string equal [ module-info mode ] "remove" ] } {
+    puts stderr "[ module-info name ] unloaded."
+}
+
+if { [ string equal [ module-info mode ] "switch1" ] } {
+    puts stderr "[ module-info name ] switched out."
+}
+EOF1
+{% if env.name == "default" and env.label == "current" %}
+cat <<'EOF2' > $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}/.version
+#%Module1.0
+
+set ModulesVersion "default-current"
+EOF2
+{% endif %}
 
 # This phase just tidies up after itself.
 %clean
@@ -32,3 +81,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 # All files in this directory are owned by this RPM.
 {{ install_prefix }}/environments/{{ env.name }}/{{ env.label }}
+{{ module_prefix }}/{{ rpm_prefix|lower }}/{{ env.name }}-{{ env.label }}
+{% if env.name == "default" and env.label == "current" %}
+{{ module_prefix }}/{{ rpm_prefix|lower }}/.version
+{% endif %}

--- a/conda_rpms/templates/env.spec.template
+++ b/conda_rpms/templates/env.spec.template
@@ -28,47 +28,41 @@ mkdir -p $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}
 cat <<'EOF1' > $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}/{{ env.name }}-{{ env.label }}
 #%Module1.0
 #
-# scitools - scientific software stack
+# scitools - scientific software stack for "{{ env.name }}/{{ env.label }}"
 #
 
-set ENV_LABEL "{{ env.name }}/{{ env.label }}"
-set BASE_DIR "/opt/scitools/environments/$ENV_LABEL"
-set HELP "Scientific software stack for the '$ENV_LABEL' environment."
-
+set LINK_DIR "/opt/scitools/environments/{{ env.name }}/{{ env.label }}"
+set BASE_DIR [ exec readlink -f $LINK_DIR ]
+set HELP "Scientific software stack for the '{{ env.name }}' environment and '{{ env.label }}' label."
 
 proc ModulesHelp { } {
+    global LINK_DIR
     global BASE_DIR
     global HELP
 
     puts stderr $HELP
     puts stderr ""
-    puts stderr "Environment base directory is $BASE_DIR"
+    puts stderr "This environment is available via:"
+    puts stderr "   - the symbolic link $LINK_DIR, or"
+    puts stderr "   - the base directory $BASE_DIR"
+    puts stderr ""
+    puts stderr "Note that, the environment symbolic link points to the environment base directory."
+    puts stderr ""
+    puts stderr "As new software is deployed to the scientific software stack, this environment"
+    puts stderr "symbolic link is automatically updated to point to the appropriate environment"
+    puts stderr "base directory."
 }
-
 
 module-whatis $HELP
 conflict scitools
 prepend-path PATH $BASE_DIR/bin
-
-if { [ module-info mode load ] } {
-    puts stderr "[ module-info name ] loaded."
-}
-
-if { [ string equal [ module-info mode ] "switch2" ] } {
-    puts stderr "[ module-info name ] switched in."
-}
-
-if { [ string equal [ module-info mode ] "remove" ] } {
-    puts stderr "[ module-info name ] unloaded."
-}
-
-if { [ string equal [ module-info mode ] "switch1" ] } {
-    puts stderr "[ module-info name ] switched out."
-}
 EOF1
 {% if env.name == "default" and env.label == "current" %}
 cat <<'EOF2' > $RPM_BUILD_ROOT{{ module_prefix }}/{{ rpm_prefix|lower }}/.version
 #%Module1.0
+#
+# scitools - scientific software stack default environment
+#
 
 set ModulesVersion "default-current"
 EOF2
@@ -82,6 +76,7 @@ rm -rf $RPM_BUILD_ROOT
 # All files in this directory are owned by this RPM.
 {{ install_prefix }}/environments/{{ env.name }}/{{ env.label }}
 {{ module_prefix }}/{{ rpm_prefix|lower }}/{{ env.name }}-{{ env.label }}
+%dir {{ module_prefix }}/{{ rpm_prefix|lower }}
 {% if env.name == "default" and env.label == "current" %}
 {{ module_prefix }}/{{ rpm_prefix|lower }}/.version
 {% endif %}


### PR DESCRIPTION
This PR adds the capability for the user to control (per session) the selection of the active environment label via [module](http://modules.sourceforge.net/man/module.html)

Each environment label rpm is now bundled with the deployment of its [modulefile](http://modules.sourceforge.net/man/modulefile.html).

The modulefile deployment is controlled via the yaml derived `config` dictionary - in particular using the new `module` -> `prefix` entry.

The default module is hardwired to be the `default`/`current` label (which seems appropriate).

The basic purpose of the modulefile is to update the users `PATH` environment variable. Note that, rather than push the environment label symbolic link onto their path, the resolved base directory is used instead in order to avoid situations where the environment link changes under their feet due to a deployment during their use of the link.
