### PR TITLE
Remove unnecessary module directory ownership

### DIFF
--- a/conda_rpms/templates/env.spec.template
+++ b/conda_rpms/templates/env.spec.template
@@ -42,7 +42,6 @@ rm -rf $RPM_BUILD_ROOT
 # All files in this directory are owned by this RPM.
 {{ env.prefix }}/environments/{{ env.name }}/{{ env.label }}
 {% if module.prefix %}
-%dir {{ module.prefix }}
 {{ module.prefix }}/{{ env.name }}-{{ env.label }}
 {% if module.default and env.name == "default" and env.label == "current" %}
 {{ module.prefix }}/.version


### PR DESCRIPTION
The creation of `label` RPMs includes the unnecessary `%dir` directive.

This means the RPM owns the directory that contains the RPM modulefile, which is not necessarily always what is wanted, particularly if we don't want ownership changing for this directory on RPM install.

See [here](http://rpm-guide.readthedocs.io/en/latest/appendix.html#files) for further clarification.