### PR TITLE
Sort packages order in the RPM based on their dependencies

### DIFF
--- a/conda_rpms/build_rpm_structure.py
+++ b/conda_rpms/build_rpm_structure.py
@@ -143,7 +143,7 @@ def create_rpmbuild_for_tag(repo, tag_name, target, config):
     index = conda.fetch.fetch_index(list(set([url for url, pkg in manifest])),
                                     use_cache=False)
     resolver = Resolve(index)
-    dists = ['::'.join(['/'.join(url.split('/')[:-1]), pkg]) for url, pkg in manifest]
+    dists = ['::'.join(os.path.dirname(url), pkg]) for url, pkg in manifest]
     sorted_dists = resolver.dependency_sort(dists)
     sorted_pkgs = [dist.split('::')[-1] for dist in sorted_dists]
 

--- a/conda_rpms/build_rpm_structure.py
+++ b/conda_rpms/build_rpm_structure.py
@@ -143,7 +143,17 @@ def create_rpmbuild_for_tag(repo, tag_name, target, config):
     index = conda.fetch.fetch_index(list(set([url for url, pkg in manifest])),
                                     use_cache=False)
     resolver = Resolve(index)
-    dists = ['::'.join(os.path.dirname(url), pkg]) for url, pkg in manifest]
+
+    # To sort the distributions must match the format of the keys of the index.
+    # For example, most should look like `http://channel::pkg
+    # However channels on anaconda go by their name rather than their url,
+    #  i.e. `conda-forge::pkg`
+    dists = []
+    for url, pkg in manifest:
+        anaconda_url = 'https://conda.anaconda.org/'
+        if url.startswith(anaconda_url):
+            url = url[len(anaconda_url):]
+        dists.append('::'.join([os.path.dirname(url), pkg]))
     sorted_dists = resolver.dependency_sort(dists)
     sorted_pkgs = [dist.split('::')[-1] for dist in sorted_dists]
 

--- a/conda_rpms/tests/unit/build_rpm_structure/test_create_rpmbuild_for_tag.py
+++ b/conda_rpms/tests/unit/build_rpm_structure/test_create_rpmbuild_for_tag.py
@@ -1,0 +1,63 @@
+from mock import patch, MagicMock
+import os
+
+import conda_rpms.tests as tests
+from conda_rpms.build_rpm_structure import create_rpmbuild_for_tag
+
+
+CONFIG = {'rpm' : {'prefix' : 'SciTools'},
+          'install' : {'prefix' : 'test_install_location'}}
+
+ENV_SPEC = """channels:
+ - https://conda.anaconda.org/conda-forge/linux-64
+env:
+ - python
+"""
+
+ENV_MANIFEST ="""https://conda.anaconda.org/conda-forge/linux-64\tca-certificates-2018.1.18-0
+https://conda.anaconda.org/conda-forge/linux-64\tncurses-5.9-10
+https://conda.anaconda.org/conda-forge/linux-64\topenssl-1.0.2n-0
+https://conda.anaconda.org/conda-forge/linux-64\tpython-3.6.4-0
+https://conda.anaconda.org/conda-forge/linux-64\tsqlite-3.20.1-2
+https://conda.anaconda.org/conda-forge/linux-64\ttk-8.6.7-0
+https://conda.anaconda.org/conda-forge/linux-64\txz-5.2.3-0
+https://conda.anaconda.org/conda-forge/linux-64\tzlib-1.2.11-0
+"""
+
+
+class Test(tests.CommonTest):
+    @patch('conda_rpms.build_rpm_structure.create_rpmbuild_for_env')
+    def test_sorted_order(self, a):
+        with self.temp_dir() as target:
+            with self.temp_dir() as temp_repo:
+                # Create fake env.spec and manifest files
+                with open(temp_repo + '/env.spec', 'w') as env_spec_file:
+                    env_spec_file.write(ENV_SPEC)
+                with open(temp_repo + '/env.manifest',
+                          'w') as env_manifest_file:
+                    env_manifest_file.write(ENV_MANIFEST)
+
+                # Set up arguments for call to create_rpmbuild_for_tag
+                repo = MagicMock()
+                repo.working_dir = temp_repo
+                tag_name = 'env-default-2018_03_26'
+                # Create directory that the spec file will be written to
+                os.mkdir(os.path.join(target, 'SPECS'))
+                create_rpmbuild_for_tag(repo, tag_name, target, CONFIG)
+
+            # Compare the written spec file with what we'd expect
+            with open(os.path.join(target, 'SPECS',
+                                   'SciTools-env-default-tag-2018_03_26.spec'),
+                      'r') as fh:
+                result_order = []
+                for line in fh.readlines():
+                    # Parse the lines of the spec file that are formatted as
+                    # `  {INSTALL} xz-5.2.3-0\n`
+                    if line.startswith('  ${INSTALL}'):
+                        result_order.append(line.split(' ')[3][:-1])
+
+            expected_order = ['ca-certificates-2018.1.18-0', 'ncurses-5.9-10',
+                              'tk-8.6.7-0', 'xz-5.2.3-0', 'zlib-1.2.11-0',
+                              'openssl-1.0.2n-0', 'sqlite-3.20.1-2',
+                              'python-3.6.4-0']
+            self.assertEqual(expected_order,result_order)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 jinja2
 gitpython
 conda-build-all
+conda-gitenv
 pyyaml
 setuptools
 mock


### PR DESCRIPTION
noarch packages need to be installed in the correct order.
For example if a noarch package needs python, when it comes to installing that package, python should already be in the environment.
To ensure this, we can sort the packages based on their dependencies...