### PR TITLE
Add option to build rpms for specific environment labels

### DIFF
--- a/conda_rpms/tests/unit/build_rpm_structure/test__env_label_filter.py
+++ b/conda_rpms/tests/unit/build_rpm_structure/test__env_label_filter.py
@@ -1,0 +1,28 @@
+from conda_rpms.build_rpm_structure import _env_label_filter
+import conda_rpms.tests as tests
+
+
+class Test(tests.CommonTest):
+    def test_match_environment_wildcard(self):
+        self.assertTrue(_env_label_filter('default', 'current',
+                                          ['*']))
+
+    def test_match_environment_label_wildcard(self):       
+        self.assertTrue(_env_label_filter('default', 'current',
+                                          ['default/*']))
+
+    def test_no_match_environment_label_wildcard(self):       
+        self.assertFalse(_env_label_filter('default', 'current',
+                                           ['experimental/*']))
+
+    def test_match_environment_label_specific(self):
+        self.assertTrue(_env_label_filter('default', 'current',
+                                          ['default/current', 'default/next']))
+
+    def test_no_match_environment_label_specific(self):
+        self.assertFalse(_env_label_filter('experimental', 'current',
+                                           ['default/current', 'default/next']))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_rpms/tests/unit/build_rpm_structure/test_create_rpmbuild_for_env.py
+++ b/conda_rpms/tests/unit/build_rpm_structure/test_create_rpmbuild_for_env.py
@@ -16,7 +16,7 @@ class Test(tests.CommonTest):
 
     def test_pkg_all_linked(self):
         func = 'conda_rpms.install.linked'
-        with patch(func, return_value=zip(*self.pkgs)[1]):
+        with patch(func, return_value=list(zip(*self.pkgs))[1]):
             with self.temp_dir() as target:
                 create_rpmbuild_for_env(self.pkgs, target, self.config)
         spec_dir = os.path.join(target, 'SPECS')


### PR DESCRIPTION
Similar to what was done with conda-gitenv, the adds the functionality to only build rpms that match the given pattern.

e.g. If you were to specific
`python build_rpm_structure ... --env_labels  default/current`
It would try to only create RPMs for the default/current env