### PR TITLE
Support API user/key with lockdown

### DIFF
--- a/conda_rpms/install.py
+++ b/conda_rpms/install.py
@@ -10,6 +10,9 @@ This is a copy of the conda/install.py script, with the additional
 https://github.com/conda/conda/pull/1222 and a collection of functions from
 conda that add support for the installation of noarch python packages.
 
+In addition, modified the create_meta function to lock-down the "conda-meta"
+directory permissions to be 0o700. See the create_meta function for details.
+
 """
 
 
@@ -301,10 +304,12 @@ def create_meta(prefix, dist, info_dir, extra_info):
     meta_dir = join(prefix, 'conda-meta')
     if not isdir(meta_dir):
         os.makedirs(meta_dir)
+        # XXX: local modification - start
         # Lock down the conda-meta directory, which may contain
         # API credentials.
         mode = S_IRUSR | S_IWUSR | S_IXUSR
         os.chmod(meta_dir, mode)
+        # XXX: local modification - end
     with open(join(meta_dir, dist + '.json'), 'w') as fo:
         json.dump(meta, fo, indent=2, sort_keys=True)
 

--- a/conda_rpms/install.py
+++ b/conda_rpms/install.py
@@ -44,7 +44,7 @@ import re
 import shlex
 import shutil
 import stat
-from stat import S_IMODE, S_IXGRP, S_IXOTH, S_IXUSR
+from stat import S_IMODE, S_IXGRP, S_IXOTH, S_IRUSR, S_IWUSR, S_IXUSR
 import subprocess
 import sys
 import tarfile
@@ -301,6 +301,10 @@ def create_meta(prefix, dist, info_dir, extra_info):
     meta_dir = join(prefix, 'conda-meta')
     if not isdir(meta_dir):
         os.makedirs(meta_dir)
+        # Lock down the conda-meta directory, which may contain
+        # API credentials.
+        mode = S_IRUSR | S_IWUSR | S_IXUSR
+        os.chmod(meta_dir, mode)
     with open(join(meta_dir, dist + '.json'), 'w') as fo:
         json.dump(meta, fo, indent=2, sort_keys=True)
 

--- a/conda_rpms/templates/installer.spec.template
+++ b/conda_rpms/templates/installer.spec.template
@@ -41,7 +41,7 @@ export DIST_PREFIX=$INSTALL_PREFIX/.pkgs/installer/$CONDA_DIST_NAME
 # The location we actually put the files.
 export BUILD_PREFIX=${RPM_BUILD_ROOT}${DIST_PREFIX}
 
-# Prepare the .pkgs and  and .envs directories.
+# Prepare the .pkgs and the .envs directories.
 mkdir -p $BUILD_PREFIX $RPM_BUILD_ROOT$INSTALL_PREFIX/.envs $RPM_BUILD_ROOT$INSTALL_PREFIX/.pkgs
 
 # Copy the contents of the conda distribution.


### PR DESCRIPTION
This PR adds support for the `--api_user=<user>` and `--api_key=<key>` optional arguments, allowing `conda-rpms` to connect to bit-repos such as artifactory.

This PR also ensures that the installed package RPMs are installed into a `conda-meta` directory that is locked-down such that API credentials are not exposed.

The (installed) RPMs package cache does not contain a `urls` nor a `urls.txt` file, thus these files do not need to be locked-down.