### PR TITLE
fix python version regex

### DIFF
--- a/conda_rpms/install.py
+++ b/conda_rpms/install.py
@@ -598,7 +598,7 @@ def get_python_version(prefix):
     """
     py_ver = None
     for dist in linked(prefix):
-        match = re.search('python-(\d+.\d+)', dist)
+        match = re.search('^python-(\d+.\d+)', dist)
         if match:
             py_ver = match.group(1)
             break


### PR DESCRIPTION
This PR adds a further fix to the `installer.py` regex for discovering the python version linked in the distribution.